### PR TITLE
add navigation support on mobile

### DIFF
--- a/blocks/navigation/navigation.css
+++ b/blocks/navigation/navigation.css
@@ -245,7 +245,7 @@
   }
 }
 
-.in-page-navigation__expand-button.in-page-navigation--expanded .icon {
+.in-page-navigation__expand-button.in-page-navigation--expanded .in-page-navigation__expand-button-icon {
   transform: rotate(180deg)
 }
 

--- a/blocks/navigation/navigation.js
+++ b/blocks/navigation/navigation.js
@@ -130,6 +130,22 @@ function addActiveLinkListener(navigation) {
   });
 }
 
+function addInteractions(nav) {
+  nav.querySelector('.in-page-navigation__expand-button').onclick = (event) => {
+    event.preventDefault();
+
+    const button = event.target;
+    const list = nav.querySelector('.in-page-navigation__navigation-list');
+    const isExpanded = nav.classList.contains('in-page-navigation--expanded');
+
+    button.classList.toggle('in-page-navigation--expanded', !isExpanded);
+    list.classList.toggle('in-page-navigation--expanded', !isExpanded);
+    nav.classList.toggle('in-page-navigation--expanded', !isExpanded);
+
+    list.style.height = isExpanded ? '0px' : `${list.childElementCount * list.firstElementChild.getBoundingClientRect().height}px`;
+  };
+}
+
 /**
  * decorates the navigation block
  * @param {Element} block The navigation block element
@@ -153,4 +169,5 @@ export default async function decorate(block) {
   const nav = block.querySelector('.in-page-navigation');
   addStickyListener(nav);
   addActiveLinkListener(nav);
+  addInteractions(nav);
 }


### PR DESCRIPTION

<img width="563" alt="Screen Shot 2022-12-01 at 5 10 10 PM" src="https://user-images.githubusercontent.com/6012307/205102728-e157678f-8412-42cc-9693-31350e577528.png">


Test URLs:
- Before: https://main--zeiss--hlxsites.hlx.page/de/semiconductor-manufacturing-technology/news-und-events/smt-pressemeldung/zeiss-trumpf-und-fraunhofer-mit-deutschem-zukunftspreis-ausgezeichnet
- After: https://nav-mobile--zeiss--hlxsites.hlx.page/de/semiconductor-manufacturing-technology/news-und-events/smt-pressemeldung/zeiss-trumpf-und-fraunhofer-mit-deutschem-zukunftspreis-ausgezeichnet