### PR TITLE
feat: image block

### DIFF
--- a/blocks/image/image.css
+++ b/blocks/image/image.css
@@ -1,0 +1,50 @@
+main .image {
+  margin: 0 auto;
+  padding-left: var(--grid-margin);
+  padding-right: var(--grid-margin);
+  max-width: 102rem;
+  margin-top: var(--spacing-vertical-xxl);
+  margin-bottom: var(--spacing-vertical-xxl);
+}
+
+main .image .figure {
+  text-align: center;
+}
+
+main .image .figure img {
+  width: 100%;
+  max-width: 100%;
+  min-width: 100%;
+}
+
+main .image figcaption {
+  position: relative;
+}
+
+main .image figcaption em:first-of-type {
+  background-color: rgba(255,255,255,.6);
+  padding-top: var(--spacing-vertical-xxs);
+  padding-right: var(--spacing-horizontal-xs);
+  padding-bottom: var(--spacing-vertical-xxs);
+  padding-left: var(--spacing-horizontal-xs);
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  bottom: 100%;
+}
+
+main .image figcaption em {
+  display: block;
+  color: var(--caption-color);
+  margin-right: var(--spacing-horizontal-xxs);
+  padding-top: var(--spacing-vertical-xs);
+  
+  font-size: 0.75rem;
+  line-height: 1rem;
+  letter-spacing: 0.5px;
+  color: var(--text-color-body);
+  font-family: var(--font-family-frutiger);
+  font-weight: normal;
+  font-style: normal;
+  text-align: left;
+}

--- a/blocks/image/image.js
+++ b/blocks/image/image.js
@@ -1,0 +1,69 @@
+/**
+ * Build figcaption element
+ * @param {Element} pEl The original element to be placed in figcaption.
+ * @returns figCaptionEl Generated figcaption
+ */
+ export function buildCaption(pEl, figCaptionEl) {
+  if (!figCaptionEl) {
+    figCaptionEl = document.createElement('figcaption');
+  }
+  pEl.classList.add('caption');
+  figCaptionEl.append(pEl);
+
+  return figCaptionEl;
+}
+
+/**
+ * Build figure element
+ * @param {Element} blockEl The original element to be placed in figure.
+ * @returns figEl Generated figure
+ */
+ function buildFigure(blockEl) {
+  const figEl = document.createElement('figure');
+  figEl.classList.add('figure');
+  let figElCaption;
+  [...blockEl.children].forEach((child) => {
+    const clone = child.cloneNode(true);
+    // picture, video, or embed link is NOT wrapped in P tag
+    if (clone.nodeName === 'PICTURE' || clone.nodeName === 'VIDEO' || clone.nodeName === 'A') {
+      figEl.prepend(clone);
+    } else {
+      // content wrapped in P tag(s)
+      const picture = clone.querySelector('picture');
+      if (picture) {
+        figEl.prepend(picture);
+      }
+      const video = clone.querySelector('video');
+      if (video) {
+        figEl.prepend(video);
+      }
+      const caption = clone.querySelector('em');
+      if (caption) {
+        if (!figElCaption) {
+          figElCaption = buildCaption(caption);
+          figEl.append(figElCaption);
+        } else {
+          buildCaption(caption, figElCaption);
+        }
+      }
+      const link = clone.querySelector('a');
+      if (link) {
+        const img = figEl.querySelector('picture') || figEl.querySelector('video');
+        if (img) {
+          // wrap picture or video in A tag
+          link.textContent = '';
+          link.append(img);
+        }
+        figEl.prepend(link);
+      }
+    }
+  });
+  return figEl;
+}
+
+export default function decorateImage(blockEl) {
+  const blockCount = blockEl.firstElementChild.childElementCount;
+  const figEl = buildFigure(blockEl.firstElementChild.firstElementChild);
+  blockEl.innerHTML = '';
+  blockEl.append(figEl);
+}

--- a/blocks/image/image.js
+++ b/blocks/image/image.js
@@ -3,14 +3,11 @@
  * @param {Element} pEl The original element to be placed in figcaption.
  * @returns figCaptionEl Generated figcaption
  */
- export function buildCaption(pEl, figCaptionEl) {
-  if (!figCaptionEl) {
-    figCaptionEl = document.createElement('figcaption');
-  }
+export function buildCaption(pEl, figCaptionEl) {
+  const fig = figCaptionEl || document.createElement('figcaption');
   pEl.classList.add('caption');
-  figCaptionEl.append(pEl);
-
-  return figCaptionEl;
+  fig.append(pEl);
+  return fig;
 }
 
 /**
@@ -18,7 +15,7 @@
  * @param {Element} blockEl The original element to be placed in figure.
  * @returns figEl Generated figure
  */
- function buildFigure(blockEl) {
+function buildFigure(blockEl) {
   const figEl = document.createElement('figure');
   figEl.classList.add('figure');
   let figElCaption;
@@ -62,7 +59,6 @@
 }
 
 export default function decorateImage(blockEl) {
-  const blockCount = blockEl.firstElementChild.childElementCount;
   const figEl = buildFigure(blockEl.firstElementChild.firstElementChild);
   blockEl.innerHTML = '';
   blockEl.append(figEl);

--- a/blocks/toc/toc.js
+++ b/blocks/toc/toc.js
@@ -170,7 +170,6 @@ export default async function decorate(block) {
     };
   }
 
-
   block.innerHTML = template({
     links,
     CTALink,


### PR DESCRIPTION
Test URLs:
- Before: https://main--zeiss--hlxsites.hlx.page/de/semiconductor-manufacturing-technology/news-und-events/smt-pressemeldung/zeiss-expandiert-in-wetzlar-weiteres-werk-im-dillfeld
- After: https://image--zeiss--hlxsites.hlx.page/de/semiconductor-manufacturing-technology/news-und-events/smt-pressemeldung/zeiss-expandiert-in-wetzlar-weiteres-werk-im-dillfeld
