### PR TITLE
Cookie consent form

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -26,10 +26,6 @@ export function getCookieConsentID(hostname) {
   return csID;
 }
 
-// The OneTrust website says to define this function like this.
-// eslint-disable-next-line no-unused-vars
-function OptanonWrapper() { }
-
 export function loadCookieConsent(doc, hostname) {
   const csID = getCookieConsentID(hostname);
 
@@ -41,7 +37,7 @@ export function loadCookieConsent(doc, hostname) {
   cookieScript.setAttribute('data-domain-script', csID);
   doc.head.appendChild(cookieScript);
 
-  const alink = doc.querySelector("a[aria-label='Trackingeinstellungen']");
+  const alink = doc.querySelector("a[aria-label='Trackingeinstellungen'], a[aria-label='Tracking Preferences']");
   if (alink) {
     alink.setAttribute('href', '#');
     alink.setAttribute('onclick', 'OneTrust.ToggleInfoDisplay();');
@@ -49,3 +45,7 @@ export function loadCookieConsent(doc, hostname) {
 }
 
 loadCookieConsent(document, window.location.hostname);
+
+// The OneTrust website says to define this function like this.
+// eslint-disable-next-line no-unused-vars
+function OptanonWrapper() { }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -5,3 +5,47 @@ import { sampleRUM } from './lib-franklin.js';
 sampleRUM('cwv');
 
 // add more delayed functionality here
+
+// eslint-disable-next-line import/prefer-default-export
+export function getCookieConsentID(hostname) {
+  if (hostname === undefined) {
+    return undefined;
+  }
+
+  // The zeiss.com cookie ID
+  let csID = '8993cba0-8683-43f1-9904-d63a3e023a9c';
+  if (hostname.endsWith('.zeiss.de')) {
+    // zeiss.de has a different cookie ID
+    csID = '11dcda2f-5845-4860-b4c1-a3e63d9f163f';
+  } else if (!hostname.endsWith('.zeiss.com')) {
+    // The OneTrust documentation specifies to suffix the ID with -test when running in
+    // a dev or stage testing domain
+    // https://about.gitlab.com/handbook/marketing/digital-experience/onetrust-cookie-consent/
+    csID += '-test';
+  }
+  return csID;
+}
+
+// The OneTrust website says to define this function like this.
+// eslint-disable-next-line no-unused-vars
+function OptanonWrapper() { }
+
+export function loadCookieConsent(doc, hostname) {
+  const csID = getCookieConsentID(hostname);
+
+  const cookieScript = doc.createElement('script');
+  cookieScript.setAttribute('src', 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js');
+  cookieScript.setAttribute('data-document-language', 'true');
+  cookieScript.setAttribute('type', 'text/javascript');
+  cookieScript.setAttribute('charset', 'UTF-8');
+  cookieScript.setAttribute('data-domain-script', csID);
+  doc.head.appendChild(cookieScript);
+
+  const alink = doc.querySelector("a[aria-label='Trackingeinstellungen']");
+  if (alink) {
+    alink.setAttribute('href', '#');
+    alink.setAttribute('onclick', 'OneTrust.ToggleInfoDisplay();');
+  }
+}
+
+loadCookieConsent(document, window.location.hostname);

--- a/test/scripts/delayed.test.js
+++ b/test/scripts/delayed.test.js
@@ -38,8 +38,8 @@ describe('Delayed functionality', () => {
     doc.head = {};
     doc.head.appendChild = (c) => appendedChildren.push(c);
     doc.createElement = (name) => (name === 'script' ? created : undefined);
-    doc.querySelector = (q) => (q === "a[aria-label='Trackingeinstellungen'], a[aria-label='Tracking Preferences']" ?
-      myalink : undefined);
+    doc.querySelector = (q) => (q === "a[aria-label='Trackingeinstellungen'], a[aria-label='Tracking Preferences']"
+      ? myalink : undefined);
 
     // Preconditions
     expect(appendedChildren.length).to.equal(0, 'Precondition');

--- a/test/scripts/delayed.test.js
+++ b/test/scripts/delayed.test.js
@@ -1,0 +1,62 @@
+/* eslint-disable no-unused-expressions */
+/* global describe before it */
+
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+let scripts;
+
+document.body.innerHTML = await readFile({ path: './dummy.html' });
+document.head.innerHTML = await readFile({ path: './head.html' });
+
+describe('Delayed functionality', () => {
+  before(async () => {
+    scripts = await import('../../scripts/delayed.js');
+    document.body.innerHTML = await readFile({ path: './body.html' });
+  });
+
+  it('Checks the Cookie Consent ID', async () => {
+    expect(scripts.getCookieConsentID('www.zeiss.com'))
+      .to.equal('8993cba0-8683-43f1-9904-d63a3e023a9c');
+    expect(scripts.getCookieConsentID('www.zeiss.de'))
+      .to.equal('11dcda2f-5845-4860-b4c1-a3e63d9f163f');
+    expect(scripts.getCookieConsentID('localhost'))
+      .to.equal('8993cba0-8683-43f1-9904-d63a3e023a9c-test');
+  });
+
+  it('Checks that the Cookie Consent script is added', async () => {
+    // Set up of 'mocks'
+    const mylinkattrs = {};
+    const myalink = {};
+    myalink.setAttribute = (k, v) => { mylinkattrs[k] = v; };
+
+    const createdAttributes = {};
+    const created = {};
+    created.setAttribute = (k, v) => { createdAttributes[k] = v; };
+    const appendedChildren = [];
+    const doc = {};
+    doc.head = {};
+    doc.head.appendChild = (c) => appendedChildren.push(c);
+    doc.createElement = (name) => (name === 'script' ? created : undefined);
+    doc.querySelector = (q) => (q === "a[aria-label='Trackingeinstellungen']" ? myalink : undefined);
+
+    // Preconditions
+    expect(appendedChildren.length).to.equal(0, 'Precondition');
+
+    // The invocation being tested
+    scripts.loadCookieConsent(doc, 'www.zeiss.com');
+
+    // Assertions about the behaviour
+    expect(appendedChildren.length).to.equal(1);
+    expect(appendedChildren[0]).to.equal(created);
+
+    expect(createdAttributes.src).to.equal('https://cdn.cookielaw.org/scripttemplates/otSDKStub.js');
+    expect(createdAttributes.type).to.equal('text/javascript');
+    expect(createdAttributes.charset).to.equal('UTF-8');
+    expect(createdAttributes['data-document-language']).to.equal('true');
+    expect(createdAttributes['data-domain-script']).to.equal('8993cba0-8683-43f1-9904-d63a3e023a9c');
+
+    expect(mylinkattrs.href).to.equal('#');
+    expect(mylinkattrs.onclick).to.equal('OneTrust.ToggleInfoDisplay();');
+  });
+});

--- a/test/scripts/delayed.test.js
+++ b/test/scripts/delayed.test.js
@@ -38,7 +38,8 @@ describe('Delayed functionality', () => {
     doc.head = {};
     doc.head.appendChild = (c) => appendedChildren.push(c);
     doc.createElement = (name) => (name === 'script' ? created : undefined);
-    doc.querySelector = (q) => (q === "a[aria-label='Trackingeinstellungen']" ? myalink : undefined);
+    doc.querySelector = (q) => (q === "a[aria-label='Trackingeinstellungen'], a[aria-label='Tracking Preferences']" ?
+      myalink : undefined);
 
     // Preconditions
     expect(appendedChildren.length).to.equal(0, 'Precondition');


### PR DESCRIPTION
Fixes #67

Also contains unit tests for the JavaScript code, which can be run with `npm t`

Test URLs:
Before: https://main--zeiss--hlxsites.hlx.page/de/semiconductor-manufacturing-technology/news-und-events/
After: https://issue-67--zeiss--hlxsites.hlx.page/de/semiconductor-manufacturing-technology/news-und-events/