### PR TITLE
i18n of back-link text via placeholders

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -16,6 +16,7 @@ main .block.hero .headline-brow {
   font-weight: 500;
   letter-spacing: 0.01em;
   line-height: 1rem;
+  padding-top: var(--spacing-vertical-l);
   text-transform: uppercase;
 }
 
@@ -30,6 +31,7 @@ main .block.hero .back-link-base svg {
   width: 1.5em;
   fill: var(--button-tertiary-text-default);
   margin-right: 4px;
+  margin-bottom: 4px;
   position: relative;
 }
 

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -1,13 +1,13 @@
 import { decorateIcons, getMetadata, fetchPlaceholders } from '../../scripts/lib-franklin.js';
 import { addClipboardInteraction } from '../../scripts/utils.js';
 
-function addBackLink(block) {
-  if (window.location.pathname.endsWith('/news-und-events/')) {
+export function addBackLink(block, locale, placeholders, curPath) {
+  if (curPath.endsWith(placeholders.newseventsbase)) {
     return;
   }
 
   const p = document.createElement('p');
-  p.innerHTML = 'Pressemitteilung';
+  p.innerHTML = placeholders.pressrelease;
   p.classList.add('headline-brow');
   block.insertBefore(p, block.firstChild);
   const hr = document.createElement('hr');
@@ -18,8 +18,9 @@ function addBackLink(block) {
   // The 2 elements are created in the 'backward' order to allow the hover over the link
   // to change the color of the arrow. They are put in the correct position via the
   // 'order' attribute in the CSS.
-  bl.innerHTML = `<a href="/de/semiconductor-manufacturing-technology/news-und-events/" class="back-link"> Zurück zu Informationen und Veranstaltungen</a>
-  <a href="#" class="back-link-icon">
+  bl.innerHTML = `<a href="/${locale}/${placeholders.newseventsbase}/"
+    class="back-link">${placeholders.backtonewsevents}</a>
+  <a href="/${locale}/${placeholders.newseventsbase}/" class="back-link-icon">
     <svg focusable="false" xmlns:xlink="http://www.w3.org/1999/xlink"">
       <use xlink:href="/icons/symbols-sprite.svg#svgsymbol-chevron-left"></use>
     </svg>
@@ -30,10 +31,11 @@ function addBackLink(block) {
 }
 
 export default async function decorate(block) {
-  addBackLink(block);
-
   const locale = getMetadata('locale') || 'en';
   const placeholders = await fetchPlaceholders(`/${locale}`);
+
+  addBackLink(block, locale, placeholders, window.location.pathname);
+
   const pub = document.querySelector('head > meta[name="publicationdate"');
   const time = document.querySelector('head > meta[name="readingtime"');
   const options = { year: 'numeric', month: 'long', day: 'numeric' };

--- a/styles/simplified-styles.css
+++ b/styles/simplified-styles.css
@@ -9,6 +9,7 @@
     --text-color-text: var(--text-color-body);
     --headline-color-eyebrow: var(--border-color-active);
     --spacing-vertical-m: 1.5rem;
+    --spacing-vertical-l: 2rem;
     --spacing-vertical-xxl: 3.5rem;
     --spacing-vertical-s: 1rem;
     --section-margin: 1.5rem;

--- a/test/blocks/hero/hero.test.js
+++ b/test/blocks/hero/hero.test.js
@@ -1,15 +1,42 @@
 /* eslint-disable no-unused-expressions */
 /* global describe it */
 
-import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
-
-document.body.innerHTML = await readFile({ path: '../../scripts/body.html' });
+import { addBackLink } from '../../../blocks/hero/hero.js';
 
 describe('Hero block', () => {
-  it('Builds hero block from picture and h1', async () => {
-    // await import('../../../scripts/scripts.js');
-    // expect(document.querySelector('.hero')).to.exist;
-    expect(true).to.be.true;
+  it('Adds backlink, ruler and eyebrow', () => {
+    const block = document.createElement('div');
+    const ph = {
+      pressrelease: 'PressRel',
+      newseventsbase: 'news/events',
+      backtonewsevents: 'back to overview',
+    };
+    addBackLink(block, 'de', ph, 'news/events/someevent');
+
+    const createdP = block.querySelector('.headline-brow');
+    expect(createdP.innerHTML).to.equal('PressRel');
+
+    const createdHR = block.querySelector('.back-link-line');
+    expect(createdHR.localName).to.equal('hr');
+
+    const createdLink = block.querySelector('.back-link');
+    expect(createdLink.getAttribute('href')).to.equal('/de/news/events/');
+    expect(createdLink.innerHTML).to.equal('back to overview');
+
+    const createdLinkArrow = block.querySelector('.back-link-icon');
+    expect(createdLinkArrow.getAttribute('href')).to.equal('/de/news/events/');
+    expect(createdLinkArrow.children[0].localName).to
+      .equal('svg', 'Link should contain an icon');
+  });
+
+  it('Backlink only on subpages', () => {
+    const block = document.createElement('div');
+    const ph = { newseventsbase: 'n/e/b' };
+
+    expect(block.childElementCount).to.equal(0, 'Precondition');
+    addBackLink(block, 'de', ph, '/foo/n/e/b');
+    expect(block.childElementCount).to
+      .equal(0, 'Should not add backlink on overview page');
   });
 });


### PR DESCRIPTION
Also added padding above Press Release text
Added unit test.

Fixes #71

Test URLs:
- Before: https://main--zeiss--hlxsites.hlx.page/en/semiconductor-manufacturing-technology/news-and-events/smt-press-releases/anniversary-50-years-smt
- After: https://issue-71c--zeiss--hlxsites.hlx.page/en/semiconductor-manufacturing-technology/news-and-events/smt-press-releases/anniversary-50-years-smt
