### PR TITLE
Support text-media block

### DIFF
--- a/blocks/text-media/text-media.css
+++ b/blocks/text-media/text-media.css
@@ -1,0 +1,19 @@
+div.text-media.block {
+    display: block !important;
+}
+
+.text-media p {
+    padding: 2px 0;
+}
+
+.text-media em {
+    font-size: 0.75rem;
+    letter-spacing: 0.005em;
+    line-height: 1rem;
+}
+
+@media (min-width: 64rem) {
+    .text-media {
+        padding: 36px 0;
+    }
+}

--- a/blocks/text-media/text-media.css
+++ b/blocks/text-media/text-media.css
@@ -1,5 +1,5 @@
-div.text-media.block {
-    display: block !important;
+.text-media.block div {
+    grid-column: 1/-1;
 }
 
 .text-media p {

--- a/blocks/text-media/text-media.js
+++ b/blocks/text-media/text-media.js
@@ -1,0 +1,1 @@
+// Empty for now

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -34,7 +34,11 @@ function buildHeroBlock(main) {
   }
 }
 
-function buildTextMediaBlock(main) {
+export function getBuildBlockFunction() {
+  return buildBlock;
+}
+
+export function buildTextMediaBlock(main, buildBlockFunction) {
   // Find blocks that contain a picture followed by an em text block. These are text-media blocks
   const pictures = main.querySelectorAll('picture');
 
@@ -56,9 +60,10 @@ function buildTextMediaBlock(main) {
             }
           }
           if (hasEMChild) {
+            const targetElement = enclosingDiv.parentElement;
             const section = document.createElement('div');
-            enclosingDiv.parentElement.insertBefore(section, enclosingDiv);
-            section.append(buildBlock('text-media', { elems: [parentP, captionP] }));
+            targetElement.insertBefore(section, enclosingDiv);
+            section.append(buildBlockFunction('text-media', { elems: [parentP, captionP] }));
           }
         }
       }
@@ -73,7 +78,7 @@ function buildTextMediaBlock(main) {
 function buildAutoBlocks(main) {
   try {
     buildHeroBlock(main);
-    buildTextMediaBlock(main);
+    buildTextMediaBlock(main, buildBlock);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -58,7 +58,7 @@ function buildTextMediaBlock(main) {
           if (hasEMChild) {
             const section = document.createElement('div');
             enclosingDiv.parentElement.insertBefore(section, enclosingDiv);
-            section.append(buildBlock('text-media', { elems: [enclosingDiv] }));
+            section.append(buildBlock('text-media', { elems: [parentP, captionP] }));
           }
         }
       }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -34,10 +34,6 @@ function buildHeroBlock(main) {
   }
 }
 
-export function getBuildBlockFunction() {
-  return buildBlock;
-}
-
 export function buildTextMediaBlock(main, buildBlockFunction) {
   // Find blocks that contain a picture followed by an em text block. These are text-media blocks
   const pictures = main.querySelectorAll('picture');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -34,6 +34,38 @@ function buildHeroBlock(main) {
   }
 }
 
+function buildTextMediaBlock(main) {
+  // Find blocks that contain a picture followed by an em text block. These are text-media blocks
+  const pictures = main.querySelectorAll('picture');
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const picture of pictures) {
+    const parentP = picture.parentElement;
+    if (parentP) {
+      const enclosingDiv = parentP.parentElement;
+      if (enclosingDiv) {
+        const captionP = parentP.nextElementSibling;
+        if (captionP) {
+          let hasEMChild = false;
+
+          // eslint-disable-next-line no-restricted-syntax
+          for (const c of captionP.children) {
+            if (c.localName === 'em') {
+              hasEMChild = true;
+              break;
+            }
+          }
+          if (hasEMChild) {
+            const section = document.createElement('div');
+            enclosingDiv.parentElement.insertBefore(section, enclosingDiv);
+            section.append(buildBlock('text-media', { elems: [enclosingDiv] }));
+          }
+        }
+      }
+    }
+  }
+}
+
 /**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
@@ -41,6 +73,7 @@ function buildHeroBlock(main) {
 function buildAutoBlocks(main) {
   try {
     buildHeroBlock(main);
+    buildTextMediaBlock(main);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -40,4 +40,99 @@ describe('Core Helix features', () => {
     const $favIcon = document.querySelector('link[rel="icon"]');
     expect($favIcon.getAttribute('href')).to.equal('/foo.svg');
   });
+
+  it('Handles Text-Media autoblocks', async () => {
+    let insertedElement;
+    let beforeElement;
+    const parentEnclosingDiv = {};
+    parentEnclosingDiv.insertBefore = (s, e) => {
+      insertedElement = s;
+      beforeElement = e;
+    };
+
+    const enclosingDiv = {};
+    enclosingDiv.parentElement = parentEnclosingDiv;
+
+    const parentP = {};
+
+    const picture = {};
+    const captionP = {};
+    picture.parentElement = parentP;
+
+    parentP.parentElement = enclosingDiv;
+    parentP.nextElementSibling = captionP;
+
+    const emChild = {};
+    emChild.localName = 'em';
+    captionP.children = [{}, emChild];
+    captionP.parentElement = parentP;
+
+    const mockMain = {};
+    mockMain.querySelectorAll = () => [picture];
+
+    let blockName;
+    let blockObj;
+    const mockBBFunction = (n, e) => {
+      blockName = n;
+      blockObj = e;
+
+      return document.createElement('myblock');
+    };
+
+    scripts.buildTextMediaBlock(mockMain, mockBBFunction);
+
+    expect(insertedElement).to.not.be.undefined;
+    expect(beforeElement).to.equal(enclosingDiv);
+
+    expect(blockName).to.equal('text-media');
+    expect(blockObj.elems).to.eql([parentP, captionP]);
+
+    expect(insertedElement.lastChild.localName).to.equal('myblock',
+      'Should have appended the block to the section');
+  });
+
+  it('No Text-Media autoblock when no <em>', async () => {
+    let insertedElement;
+    let beforeElement;
+    const parentEnclosingDiv = {};
+    parentEnclosingDiv.insertBefore = (s, e) => {
+      insertedElement = s;
+      beforeElement = e;
+    };
+
+    const enclosingDiv = {};
+    enclosingDiv.parentElement = parentEnclosingDiv;
+
+    const parentP = {};
+
+    const picture = {};
+    const captionP = {};
+    picture.parentElement = parentP;
+
+    parentP.parentElement = enclosingDiv;
+    parentP.nextElementSibling = captionP;
+
+    const emChild = {};
+    emChild.localName = 'strong';
+    captionP.children = [{}, emChild];
+    captionP.parentElement = parentP;
+
+    const mockMain = {};
+    mockMain.querySelectorAll = () => [picture];
+
+    let blockName;
+    let blockObj;
+    const mockBBFunction = (n, e) => {
+      blockName = n;
+      blockObj = e;
+
+      return document.createElement('myblock');
+    };
+
+    scripts.buildTextMediaBlock(mockMain, mockBBFunction);
+
+    expect(insertedElement).to.be.undefined;
+    expect(blockName).to.be.undefined;
+    expect(blockObj).to.undefined;
+  });
 });

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -87,17 +87,15 @@ describe('Core Helix features', () => {
     expect(blockName).to.equal('text-media');
     expect(blockObj.elems).to.eql([parentP, captionP]);
 
-    expect(insertedElement.lastChild.localName).to.equal('myblock',
-      'Should have appended the block to the section');
+    expect(insertedElement.lastChild.localName).to
+      .equal('myblock', 'Should have appended the block to the section');
   });
 
   it('No Text-Media autoblock when no <em>', async () => {
     let insertedElement;
-    let beforeElement;
     const parentEnclosingDiv = {};
-    parentEnclosingDiv.insertBefore = (s, e) => {
+    parentEnclosingDiv.insertBefore = (s) => {
       insertedElement = s;
-      beforeElement = e;
     };
 
     const enclosingDiv = {};


### PR DESCRIPTION
This approach follows the autoblocking approach (as suggested in https://www.hlx.live/docs/davidsmodel ) by identifying text-media blocks as an image with an entirely italic (&lt;em>) text paragraph (the caption) after it.

Fixes #105

Test URLs:

* Before: https://main--zeiss--hlxsites.hlx.page/en/semiconductor-manufacturing-technology/news-and-events/smt-press-releases/2023/zeiss-expands-at-the-rossdorf-research-and-development-site
* After: https://issue-105--zeiss--hlxsites.hlx.page/en/semiconductor-manufacturing-technology/news-and-events/smt-press-releases/2023/zeiss-expands-at-the-rossdorf-research-and-development-site
