### PR TITLE
Issue-148 Collapse block is wider on Franklin

### DIFF
--- a/blocks/collapse/collapse.css
+++ b/blocks/collapse/collapse.css
@@ -21,6 +21,12 @@
   }
 }
 
+@media (min-width: 102rem) {
+  .collapse-container {
+      max-width: 71.5rem !important;
+  }
+}
+
 .collapse > div:nth-child(1) {
   margin-bottom: var(--spacing-vertical-s);
   text-align: left;

--- a/styles/simplified-styles.css
+++ b/styles/simplified-styles.css
@@ -104,6 +104,12 @@ main .section:not(.carousel-container):not(.text-block):not(.contact-container):
     box-sizing: border-box
 }
 
+@media (min-width: 102rem) {
+    main .section.collapse-container {
+        max-width: 71.5rem !important;
+    }
+}
+
 /* TODO: Block not yet simplified are added as :not exceptions. This list  should shrink as we simplify sections */
 .block:not(.header):not(.cards):not(.collapse):not(.carousel):not(.contact):not(.columns):not(.article-list):not(.footer):not(.columns-new) {
     position: relative;

--- a/styles/simplified-styles.css
+++ b/styles/simplified-styles.css
@@ -104,12 +104,6 @@ main .section:not(.carousel-container):not(.text-block):not(.contact-container):
     box-sizing: border-box
 }
 
-@media (min-width: 102rem) {
-    main .section.collapse-container {
-        max-width: 71.5rem !important;
-    }
-}
-
 /* TODO: Block not yet simplified are added as :not exceptions. This list  should shrink as we simplify sections */
 .block:not(.header):not(.cards):not(.collapse):not(.carousel):not(.contact):not(.columns):not(.article-list):not(.footer):not(.columns-new) {
     position: relative;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #148 

Test URLs:
- Before: https://main--zeiss--hlxsites.hlx.page/en/semiconductor-manufacturing-technology/news-and-events/smt-press-releases-21-Apr-23-bkp/quality-supplier-award-2019
- After: https://issue-148--zeiss--hlxsites.hlx.page/en/semiconductor-manufacturing-technology/news-and-events/smt-press-releases-21-Apr-23-bkp/quality-supplier-award-2019
