### PR TITLE
Fixes for text media autoblock

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -34,6 +34,56 @@ function buildHeroBlock(main) {
   }
 }
 
+function indexOfElementInParent(element) {
+  return [...element.parentElement.children].indexOf(element);
+}
+
+/**
+ * Split children of this div up into 1, 2 or 3 separate divs with cut points as specified in
+ * the from and to indexes, separating the elements from-to into
+ * a separate div on the same level and putting the remaining elements in new divs surrounding it.
+ * @param {HTMLElement} div The element to work on.
+ * @param {number} from The index from from which to put element into the middle div.
+ * @param {number} to The index up-to-but-not-including the element that marks then end of the
+ * middle div.
+ * @returns Returns the middle div.
+ */
+export function splitChildDiv(div, from, to) {
+  // run backwards because moving element will delete them from the original
+
+  let afterDiv;
+  if (to < div.children.length - 1) {
+    afterDiv = document.createElement('div');
+    for (let i = div.children.length - 1; i >= to; i -= 1) {
+      afterDiv.prepend(div.children[i]);
+    }
+  }
+
+  const midDiv = document.createElement('div');
+  for (let i = to - 1; i >= from; i -= 1) {
+    midDiv.prepend(div.children[i]);
+  }
+
+  let beforeDiv;
+  if (from > 0) {
+    beforeDiv = document.createElement('div');
+    for (let i = from - 1; i >= 0; i -= 1) {
+      beforeDiv.prepend(div.children[i]);
+    }
+  }
+
+  if (beforeDiv) {
+    div.parentElement.insertBefore(beforeDiv, div);
+  }
+  div.parentElement.insertBefore(midDiv, div);
+  if (afterDiv) {
+    div.parentElement.insertBefore(afterDiv, div);
+  }
+  div.parentElement.removeChild(div);
+
+  return midDiv;
+}
+
 export function buildTextMediaBlock(main, buildBlockFunction) {
   // Find blocks that contain a picture followed by an em text block. These are text-media blocks
   const pictures = main.querySelectorAll('picture');
@@ -47,7 +97,6 @@ export function buildTextMediaBlock(main, buildBlockFunction) {
         const captionP = parentP.nextElementSibling;
         if (captionP) {
           let hasEMChild = false;
-
           // eslint-disable-next-line no-restricted-syntax
           for (const c of captionP.children) {
             if (c.localName === 'em') {
@@ -55,10 +104,10 @@ export function buildTextMediaBlock(main, buildBlockFunction) {
               break;
             }
           }
+
           if (hasEMChild) {
-            const targetElement = enclosingDiv.parentElement;
-            const section = document.createElement('div');
-            targetElement.insertBefore(section, enclosingDiv);
+            const idx = indexOfElementInParent(parentP);
+            const section = splitChildDiv(enclosingDiv, idx, idx + 2);
             section.append(buildBlockFunction('text-media', { elems: [parentP, captionP] }));
           }
         }


### PR DESCRIPTION
This fix makes the autoblock independent of the number of other parts surrounding it.
Contributes toward #126 point 8

Test URLs:

- Before: https://main--zeiss--hlxsites.hlx.page/en/semiconductor-manufacturing-technology/news-and-events/smt-press-releases/anniversary-50-years-smt
- After: https://issue-126_8--zeiss--hlxsites.hlx.page/en/semiconductor-manufacturing-technology/news-and-events/smt-press-releases/anniversary-50-years-smt
