### PR TITLE
`Further Information` incorrectly styled

### DIFF
--- a/styles/simplified-styles.css
+++ b/styles/simplified-styles.css
@@ -95,6 +95,35 @@ em > a:hover::after {
     padding-bottom: 0
 }
 
+.text-block a {
+  display: inline-block;
+  position: relative;
+  color: var(--text-color-body);
+  font-weight: normal;
+  text-decoration: none;
+  transition: color .75s;
+  outline: none;
+}
+
+.text-block a:hover {
+    color: var(--text-color-link-hover);
+}
+
+.text-block a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-top: 1px solid var(--button-tertiary-underline-default);
+  animation-duration: .75s;
+}
+
+.text-block a:hover:after {
+  background-color: var(--button-tertiary-underline-hover);
+  animation-name: hover;
+}
+
 /* section */
 @media (min-width: 22.5rem) {
     :root {

--- a/styles/simplified-styles.css
+++ b/styles/simplified-styles.css
@@ -47,7 +47,7 @@ a:hover {
     color: var(--button-primary-border-hover);
 }
 
-em > a {
+:is(em, .text-block) a {
     display: inline-block;
     position: relative;
     color: inherit;
@@ -56,11 +56,11 @@ em > a {
     outline: none;
 }
 
-em> a:hover {
+:is(em, .text-block) a:hover {
     color: var(--text-color-link-hover);
 }
 
-em > a::after {
+:is(em, .text-block) a::after {
     content: "";
     position: absolute;
     left: 0;
@@ -70,7 +70,7 @@ em > a::after {
     animation-duration: .75s;
 }
 
-em > a:hover::after {
+:is(em, .text-block) a:hover:after {
     background-color: var(--button-tertiary-underline-hover);
     animation-name: hover;
 }
@@ -93,35 +93,6 @@ em > a:hover::after {
 .text-block p:only-of-type {
     padding-top: 0;
     padding-bottom: 0
-}
-
-.text-block a {
-  display: inline-block;
-  position: relative;
-  color: var(--text-color-body);
-  font-weight: normal;
-  text-decoration: none;
-  transition: color .75s;
-  outline: none;
-}
-
-.text-block a:hover {
-    color: var(--text-color-link-hover);
-}
-
-.text-block a::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  border-top: 1px solid var(--button-tertiary-underline-default);
-  animation-duration: .75s;
-}
-
-.text-block a:hover:after {
-  background-color: var(--button-tertiary-underline-hover);
-  animation-name: hover;
 }
 
 /* section */


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #189

Test URLs:
- Before: https://main--zeiss--hlxsites.hlx.page/en/semiconductor-manufacturing-technology/news-and-events/smt-press-releases/quality-supplier-award-2019
- After: https://issue-189--zeiss--hlxsites.hlx.page/en/semiconductor-manufacturing-technology/news-and-events/smt-press-releases/quality-supplier-award-2019
