### PR TITLE
Add sitemap

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,0 +1,12 @@
+sitemaps:
+   website:
+     origin: https://www.zeiss.com
+     languages:
+       de:
+         source: /de/semiconductor-manufacturing-technology/news-und-events/query-index.json
+         destination: /de/semiconductor-manufacturing-technology/news-und-events/sitemap.xml
+         hreflang: de
+       en:
+         source: /en/semiconductor-manufacturing-technology/news-and-events/query-index.json
+         destination: /en/semiconductor-manufacturing-technology/news-and-events/sitemap.xml
+         hreflang: en

--- a/sitemap-index.xml
+++ b/sitemap-index.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>
+      https://www.zeiss.com/de/semiconductor-manufacturing-technology/news-und-events/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>
+      https://www.zeiss.com/en/semiconductor-manufacturing-technology/news-and-events/sitemap.xml</loc>
+  </sitemap>
+</sitemapindex>


### PR DESCRIPTION
[Sitemap definition](https://github.com/hlxsites/zeiss/pull/203/files#diff-5c22d7e9cc4cc3773db529ef11b0b0275e0704d96173caa9718c1a957a2d15a3) - Generates 2 sitemaps, one for `en` other for `de`
[Sitemap Index](https://github.com/hlxsites/zeiss/pull/203/files#diff-6da918dd5150a5af3884a88d23aa89b44cc2a1e48a2c0daa6bbbbd6ab4d00f17) - Contains links to both the generated sitemaps
[Generated English Sitemap](https://main--zeiss--hlxsites.hlx.page/en/semiconductor-manufacturing-technology/news-and-events/sitemap.xml)
[Generated German Sitemap](https://main--zeiss--hlxsites.hlx.page/de/semiconductor-manufacturing-technology/news-und-events/sitemap.xml)

Fix #63 

Test URLs:
- Before: https://main--zeiss--hlxsites.hlx.page
- After: https://sitemap--zeiss--hlxsites.hlx.page
