### PR TITLE
issue-208 Hero href changed

### DIFF
--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -19,9 +19,9 @@ export function addBackLink(block, locale, placeholders, curPath) {
   // The 2 elements are created in the 'backward' order to allow the hover over the link
   // to change the color of the arrow. They are put in the correct position via the
   // 'order' attribute in the CSS.
-  bl.innerHTML = `<a href="/${locale}/${placeholders.newseventsbase}/"
+  bl.innerHTML = `<a href=${placeholders.herohref}
     class="back-link">${placeholders.backtonewsevents}</a>
-  <a href="/${locale}/${placeholders.newseventsbase}/" class="back-link-icon">
+  <a href=${placeholders.herohref} class="back-link-icon">
     <svg focusable="false" xmlns:xlink="http://www.w3.org/1999/xlink"">
       <use xlink:href="/icons/symbols-sprite.svg#svgsymbol-chevron-left"></use>
     </svg>

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -19,9 +19,9 @@ export function addBackLink(block, locale, placeholders, curPath) {
   // The 2 elements are created in the 'backward' order to allow the hover over the link
   // to change the color of the arrow. They are put in the correct position via the
   // 'order' attribute in the CSS.
-  bl.innerHTML = `<a href=${placeholders.herohref}
+  bl.innerHTML = `<a href=${placeholders.newsandeventsurl}
     class="back-link">${placeholders.backtonewsevents}</a>
-  <a href=${placeholders.herohref} class="back-link-icon">
+  <a href=${placeholders.newsandeventsurl} class="back-link-icon">
     <svg focusable="false" xmlns:xlink="http://www.w3.org/1999/xlink"">
       <use xlink:href="/icons/symbols-sprite.svg#svgsymbol-chevron-left"></use>
     </svg>

--- a/test/blocks/hero/hero.test.js
+++ b/test/blocks/hero/hero.test.js
@@ -31,7 +31,7 @@ describe('Hero block', () => {
       pressrelease: 'PressRel',
       newseventsbase: 'news/events',
       backtonewsevents: 'back to overview',
-      herohref: 'https://www.zeiss.de/semiconductor-manufacturing-technology/news-und-events.html',
+      newsandeventsurl: 'https://www.zeiss.de/semiconductor-manufacturing-technology/news-und-events.html',
     };
     addBackLink(block, 'de', ph, 'news/events/someevent');
 

--- a/test/blocks/hero/hero.test.js
+++ b/test/blocks/hero/hero.test.js
@@ -31,6 +31,7 @@ describe('Hero block', () => {
       pressrelease: 'PressRel',
       newseventsbase: 'news/events',
       backtonewsevents: 'back to overview',
+      herohref: 'https://www.zeiss.de/semiconductor-manufacturing-technology/news-und-events.html',
     };
     addBackLink(block, 'de', ph, 'news/events/someevent');
 
@@ -41,11 +42,11 @@ describe('Hero block', () => {
     expect(createdHR.localName).to.equal('hr');
 
     const createdLink = block.querySelector('.back-link');
-    expect(createdLink.getAttribute('href')).to.equal('/de/news/events/');
+    expect(createdLink.getAttribute('href')).to.equal('https://www.zeiss.de/semiconductor-manufacturing-technology/news-und-events.html');
     expect(createdLink.innerHTML).to.equal('back to overview');
 
     const createdLinkArrow = block.querySelector('.back-link-icon');
-    expect(createdLinkArrow.getAttribute('href')).to.equal('/de/news/events/');
+    expect(createdLinkArrow.getAttribute('href')).to.equal('https://www.zeiss.de/semiconductor-manufacturing-technology/news-und-events.html');
     expect(createdLinkArrow.children[0].localName).to
       .equal('svg', 'Link should contain an icon');
   });


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #208 

Test URLs:
- Before: https://main--zeiss--hlxsites.hlx.live/en/semiconductor-manufacturing-technology/news-and-events/smt-press-releases/anniversary-50-years-smt
- After: https://issue-208--zeiss--hlxsites.hlx.live/en/semiconductor-manufacturing-technology/news-and-events/smt-press-releases/anniversary-50-years-smt
