### PR TITLE
Improve image alt support

### DIFF
--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -190,13 +190,6 @@ export default async function decorate(block) {
         copyright = copyright.substring(1);
       }
     }
-
-    const img = image.querySelector('img');
-    if (img) {
-      img.alt = img.alt || label;
-      img.title = img.title || label;
-    }
-
     return {
       image: image.outerHTML,
       label,

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -18,7 +18,7 @@ indices:
         select: head > meta[name="description"]
         value: attribute(el, "content")
       imagealt:
-        select: head > meta[property="imagealt"]
+        select: head > meta[property="og:image:alt"]
         value: attribute(el, "content")
       publicationdate:
         select: head > meta[name="publicationdate"]
@@ -48,7 +48,7 @@ indices:
         select: head > meta[name="description"]
         value: attribute(el, "content")
       imagealt:
-        select: head > meta[property="imagealt"]
+        select: head > meta[property="og:image:alt"]
         value: attribute(el, "content")
       publicationdate:
         select: head > meta[name="publicationdate"]

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -18,7 +18,7 @@ indices:
         select: head > meta[name="description"]
         value: attribute(el, "content")
       imagealt:
-        select: head > meta[property="og:image:alt"]
+        select: head > meta[property="imagealt"]
         value: attribute(el, "content")
       publicationdate:
         select: head > meta[name="publicationdate"]
@@ -48,7 +48,7 @@ indices:
         select: head > meta[name="description"]
         value: attribute(el, "content")
       imagealt:
-        select: head > meta[property="og:image:alt"]
+        select: head > meta[property="imagealt"]
         value: attribute(el, "content")
       publicationdate:
         select: head > meta[name="publicationdate"]

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -170,7 +170,7 @@ const createMetadata = (main, document, url) => {
     }
   }
   if (imagealt) {
-    meta.imagealt = imagealt.content;
+    meta['Image-Alt'] = imagealt.content;
   }
 
   // iterate over tagsMap

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -159,16 +159,8 @@ const createMetadata = (main, document, url) => {
     meta.Image = el;
   }
 
-  // Preference for image alt tag is og:image:alt > og:title > title
-  let imagealt = document.querySelector('[property="og:image:alt"]');
-  if (imagealt === null || imagealt === undefined) {
-    const ogTitle = document.querySelector('[property="og:title"]');
-    if (ogTitle) {
-      imagealt = document.querySelector('[property="og:title"]');
-    } else {
-      imagealt = title;
-    }
-  }
+  // Preference order for image alt tag is og:image:alt > og:title > title
+  const imagealt = document.querySelector('[property="og:image:alt"]') || document.querySelector('[property="og:title"]') || title;
   if (imagealt) {
     meta['Image-Alt'] = imagealt.content;
   }

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -159,6 +159,20 @@ const createMetadata = (main, document, url) => {
     meta.Image = el;
   }
 
+  // Preference for image alt tag is og:image:alt > og:title > title
+  let imagealt = document.querySelector('[property="og:image:alt"]');
+  if (imagealt === null || imagealt === undefined) {
+    const ogTitle = document.querySelector('[property="og:title"]');
+    if (ogTitle) {
+      imagealt = document.querySelector('[property="og:title"]');
+    } else {
+      imagealt = title;
+    }
+  }
+  if (imagealt) {
+    meta.imagealt = imagealt.content;
+  }
+
   // iterate over tagsMap
   const tags = [];
   Object.entries(tagsMap).forEach(([key, value]) => {


### PR DESCRIPTION
Fix #115 

Test URLs:
- Before: https://main--zeiss--hlxsites.hlx.page/drafts/satyam/sample-template
- After: https://issue-115b--zeiss--hlxsites.hlx.page/drafts/satyam/sample-template

P.S. Note the difference in the `img[alt]` attributes between the 2 branches. 
